### PR TITLE
Fix build error when swig is not found

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,7 +95,7 @@
     - build-essential
     - automake
     - gtk-doc-tools
-    - swig2.0
+    - swig
     - gobject-introspection
     - pkg-config
     - libglib2.0-dev


### PR DESCRIPTION
Even though the 'swig2.0' executable exists, the VIPS bootstrap script looks for
an executable named 'swig' and fails if it's not found:

```
./bootstrap.sh: 71: ./bootstrap.sh: swig: not found
you need swig to build from source control
```

Installing the swig package, which depends on the swig2.0 package, fixes the
VIPS build by providing a symlink from 'swig' to 'swig2.0'.
